### PR TITLE
Validate OWNERS file

### DIFF
--- a/KUBERNETES_CSI_OWNERS_ALIASES
+++ b/KUBERNETES_CSI_OWNERS_ALIASES
@@ -31,15 +31,7 @@ aliases:
 
 # This documents who previously contributed to Kubernetes-CSI
 # as approver.
-emeritus_approver:
+emeritus_approvers:
 - lpabon
-- sbezverk
-- vladimirvivien
-
-# This documents who previously contributed to Kubernetes-CSI
-# as reviewer.
-emeritus_reviewer:
-- lpabon
-- saad-ali
 - sbezverk
 - vladimirvivien


### PR DESCRIPTION
- supported section name is `emeritus_approvers` (so add a `s`)
- there isn't a supported section for emeritus reviewers (so remove the entire section)

please see https://go.k8s.io/owners for additional info and https://github.com/kubernetes/community/issues/6334 with a bunch of other cleanups we are doing.